### PR TITLE
Make code mostly Python3 compliant

### DIFF
--- a/mclf/__init__.py
+++ b/mclf/__init__.py
@@ -1,16 +1,12 @@
-
-# this is necessary for the documentation building:
-from sage.all_cmdline import *
-
-from curves.smooth_projective_curves import *
-from curves.morphisms_of_smooth_projective_curves import *
-from berkovich.berkovich_line import *
-from berkovich.berkovich_trees import *
-from berkovich.type_V_points import *
-from berkovich.affinoid_domain import *
-from semistable_reduction.superp import *
-from semistable_reduction.superell import *
-from padic_extensions.weak_padic_galois_extensions import *
-from padic_extensions.fake_padic_completions import *
-from padic_extensions.fake_padic_embeddings import *
-from semistable_reduction.reduction_trees import *
+from .curves.smooth_projective_curves import *
+from .curves.morphisms_of_smooth_projective_curves import *
+from .berkovich.berkovich_line import *
+from .berkovich.berkovich_trees import *
+from .berkovich.type_V_points import *
+from .berkovich.affinoid_domain import *
+from .semistable_reduction.superp import *
+from .semistable_reduction.superell import *
+from .padic_extensions.weak_padic_galois_extensions import *
+from .padic_extensions.fake_padic_completions import *
+from .padic_extensions.fake_padic_embeddings import *
+from .semistable_reduction.reduction_trees import *

--- a/mclf/berkovich/affinoid_domain.py
+++ b/mclf/berkovich/affinoid_domain.py
@@ -58,8 +58,7 @@ TO DO:
 #*****************************************************************************
 
 
-from sage.structure.sage_object import SageObject
-from sage.rings.infinity import Infinity
+from sage.all import SageObject, Infinity
 from mclf.berkovich.berkovich_line import BerkovichLine, TypeIPointOnBerkovichLine,\
                                           TypeIIPointOnBerkovichLine
 from mclf.berkovich.type_V_points import TypeVPointOnBerkovichLine
@@ -332,22 +331,22 @@ class AffinoidTree(BerkovichTree):
             T_new, dump = T_new.add_point(xi0, None)
         for xi1 in T1.vertices():
             T_new, dump = T_new.add_point(xi1, None)
-        # print "First step of T_new:", T_new.vertices()
+        # print("First step of T_new:", T_new.vertices())
         new_out = []
         for subtree in T_new.subtrees():
             xi = subtree.root()
-            # print "adding xi =", xi
+            # print("adding xi =", xi)
             xi_in_T0 = T0.is_in_affinoid(xi)
             xi_in_T1 = T1.is_in_affinoid(xi)
-            # print xi_in_T0, xi_in_T1
+            # print(xi_in_T0, xi_in_T1)
             if xi_in_T0 == xi_in_T1:
                 subtree._is_in_affinoid = xi_in_T0
-                # print "xi is in union: ", xi_in_T0
-                # print
+                # print("xi is in union: ", xi_in_T0)
+                # print()
             else:
                 subtree._is_in_affinoid = True
-                # print "xi is in union!"
-                # print
+                # print("xi is in union!")
+                # print()
                 if subtree.has_parent():
                     parent = subtree.parent()
                     xi0 = parent.root()
@@ -355,7 +354,7 @@ class AffinoidTree(BerkovichTree):
                     xi0_in_T1 = T1.is_in_affinoid(xi0)
                     if (xi_in_T0 != xi0_in_T0) and (xi0_in_T0 != xi0_in_T1):
                         new_out.append(xi0.point_in_between(xi))
-                        # print "we have to exclude ", xi0
+                        # print("we have to exclude ", xi0)
         T_new = T_new.add_points([], new_out)
         return T_new
 
@@ -401,8 +400,8 @@ class AffinoidTree(BerkovichTree):
                 in_list.append(i)
             else:
                 out_list.append(i)
-            print i, ": ", xi
-        # print vertex_dict
+            print(i, ": ", xi)
+        # print(vertex_dict)
         G.show(partition=[in_list, out_list])
 
     def compute_connected_components(self, comp_list, new_comp):

--- a/mclf/berkovich/berkovich_line.py
+++ b/mclf/berkovich/berkovich_line.py
@@ -97,15 +97,9 @@ TO DO:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
-from sage.functions.generalized import sgn
-from sage.geometry.newton_polygon import NewtonPolygon
-from sage.rings.valuation.gauss_valuation import GaussValuation
+from sage.all import SageObject, PolynomialRing, cached_method, Infinity, sgn, GaussValuation
 from sage.rings.valuation.limit_valuation import LimitValuation
-
+from sage.geometry.newton_polygon import NewtonPolygon
 
 
 class BerkovichLine(SageObject):
@@ -483,9 +477,9 @@ class BerkovichLine(SageObject):
         NP = NewtonPolygon([(i, vK(f[i])) for i in range(f.degree() + 1)])
         slopes = NP.slopes(False)
         if not (slopes == [] or max(slopes) <= 0 or min(slopes) >0):
-            print "f = ", f
-            print "NP = ", NP
-            print "slopes = ", NP.slopes(False)
+            print("f = ", f)
+            print("NP = ", NP)
+            print("slopes = ", NP.slopes(False))
         assert slopes == [] or max(slopes) <= 0 or min(slopes) >0,\
             "all roots of f must either lie inside or outside the unit disk"
         is_in_unit_disk = (slopes == [] or max(slopes) <= 0)
@@ -606,7 +600,7 @@ class PointOnBerkovichLine(SageObject):
 
         R = self._v._base_valuation.domain()
         if f.parent() is self.berkovich_line().function_field() and not self.is_in_unit_disk():
-            print "f =", f
+            print("f =", f)
             return R(f(1/self.berkovich_line().function_field().gen()))
         else:
             return R(f)

--- a/mclf/berkovich/berkovich_path.py
+++ b/mclf/berkovich/berkovich_path.py
@@ -37,9 +37,7 @@ Moreover, kinks of this function can only occur in points of type II.
 
 """
 
-from sage.structure.sage_object import SageObject
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
+from sage.all import SageObject, cached_method, Infinity
 from mclf.berkovich.berkovich_line import BerkovichLine
 from mclf.berkovich.type_V_points import TypeVPointOnBerkovichLine
 

--- a/mclf/berkovich/berkovich_path_old.py
+++ b/mclf/berkovich/berkovich_path_old.py
@@ -37,9 +37,7 @@ Moreover, kinks of this function can only occur in points of type II.
 
 """
 
-from sage.structure.sage_object import SageObject
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
+from sage.all import SageObject, cached_method, Infinity
 from mclf.berkovich.berkovich_line import BerkovichLine
 from mclf.berkovich.type_V_points import TypeVPointOnBerkovichLine
 

--- a/mclf/berkovich/berkovich_trees.py
+++ b/mclf/berkovich/berkovich_trees.py
@@ -46,8 +46,7 @@ EXAMPLES::
 #*****************************************************************************
 
 
-from sage.structure.sage_object import SageObject
-from sage.graphs.graph import Graph
+from sage.all import SageObject, Graph
 from mclf.berkovich.berkovich_line import BerkovichLine
 
 
@@ -73,15 +72,15 @@ class BerkovichTree(SageObject):
     """
     def __init__(self, X, root=None, children=None, parent=None):
 
-        # print "calling BerkovichTree with root %s, children %s and
-        # parent %s"%(root, children, parent)
+        # print("calling BerkovichTree with root %s, children %s and
+        # parent %s"%(root, children, parent))
         self._root = root
         if children == None:
             self._children = []
         else:
             self._children = children
         if root == None and self._children != []:
-            raise ValueError, "tree with children must have a root"
+            raise ValueError("tree with children must have a root")
 
         self._parent = parent
         self._X = X
@@ -340,7 +339,7 @@ class BerkovichTree(SageObject):
 
         if self._root == None:
             return
-        print "___"*depth, " ", self._root
+        print("___"*depth, " ", self._root)
         for T in self._children:
             T.print_tree(depth + 1)
 
@@ -523,18 +522,18 @@ def component_jumps(xi0, xi1):
     T = S.gen()
     G = phi(x+T)
     NP = NewtonPolygon([(i, v1(G[i])) for i in range(G.degree()+1)])
-    # print "phi = ", phi
-    # print "G = ", G
-    # print "NP = ", NP
+    # print("phi = ", phi)
+    # print("G = ", G)
+    # print("NP = ", NP)
     V = []
     vertices =  NP.vertices()
     for k in range(len(vertices)-1):
         i, ai = vertices[k]
         j, aj = vertices[k+1]
         a0 = aj - j*(ai-aj)/(i-j)
-        # print "a0 = ", a0
+        # print("a0 = ", a0)
         V += valuations_from_inequality(vK, phi, a0, v0)
-    # print "V = ", V
+    # print("V = ", V)
     if xi1.is_in_unit_disk():
         ret = [X.point_from_polynomial_pseudovaluation(v) for v in V]
     else:

--- a/mclf/berkovich/piecewise_affine_function.py
+++ b/mclf/berkovich/piecewise_affine_function.py
@@ -5,9 +5,7 @@ r""" Piecewise affine functions on the positive real line.
 
 """
 
-from sage.structure.sage_object import SageObject
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
+from sage.all import SageObject, cached_method, Infinity
 
 
 class PiecewiseAffineFunction(SageObject):

--- a/mclf/berkovich/type_V_points.py
+++ b/mclf/berkovich/type_V_points.py
@@ -5,9 +5,7 @@ r""" Points of type V on the Berkovich line.
 """
 
 
-from sage.structure.sage_object import SageObject
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
+from sage.all import SageObject, cached_method, Infinity
 from mclf.berkovich.berkovich_line import BerkovichLine
 
 

--- a/mclf/berkovich/valuative_functions.py
+++ b/mclf/berkovich/valuative_functions.py
@@ -63,10 +63,7 @@ EXAMPLES::
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
-from mac_lane import *
+from sage.all import SageObject, cached_method, Infinity
 
 
 class ValuativeFunction(SageObject):

--- a/mclf/curves/__init__.py
+++ b/mclf/curves/__init__.py
@@ -1,3 +1,3 @@
 
-from smooth_projective_curves import SmoothProjectiveCurve, PointOnSmoothProjectiveCurve
-from morphisms_of_smooth_projective_curves import MorphismOfSmoothProjectiveCurves
+from .smooth_projective_curves import SmoothProjectiveCurve, PointOnSmoothProjectiveCurve
+from .morphisms_of_smooth_projective_curves import MorphismOfSmoothProjectiveCurves

--- a/mclf/curves/morphisms_of_smooth_projective_curves.py
+++ b/mclf/curves/morphisms_of_smooth_projective_curves.py
@@ -41,8 +41,7 @@ EXAMPLES::
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from sage.rings.all import Infinity, ZZ, PolynomialRing
+from sage.all import SageObject, Infinity, ZZ, PolynomialRing
 from mclf.curves.smooth_projective_curves import PointOnSmoothProjectiveCurve
 
 

--- a/mclf/curves/smooth_projective_curves.py
+++ b/mclf/curves/smooth_projective_curves.py
@@ -85,12 +85,7 @@ EXAMPLES::
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from sage.rings.all import Infinity, ZZ, PolynomialRing
-from sage.misc.prandom import randint
-from sage.misc.misc_c import prod
-from sage.rings.power_series_ring import PowerSeriesRing
-from sage.misc.cachefunc import CachedFunction
+from sage.all import SageObject, Infinity, ZZ, PolynomialRing, randint, prod, PowerSeriesRing, CachedFunction
 
 
 class SmoothProjectiveCurve(SageObject):
@@ -520,7 +515,7 @@ class SmoothProjectiveCurve(SageObject):
 
         """
         if not self._is_separable:
-            raise Error, "Y is not separable, hence the ramification divisor is not defined"
+            raise Error("Y is not separable, hence the ramification divisor is not defined")
         if hasattr(self, "_ramification_divisor"):
             return self._ramification_divisor
 

--- a/mclf/padic_extensions/elements_of_fake_padic_completion.py
+++ b/mclf/padic_extensions/elements_of_fake_padic_completion.py
@@ -27,27 +27,9 @@ TO DO:
 #*****************************************************************************
 
 
-from sage.structure.sage_object import SageObject
-from sage.rings.integer_ring import IntegerRing
-from sage.rings.rational_field import RationalField
-from sage.rings.number_field.number_field import NumberField
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.polynomial.polynomial_element import Polynomial
-from sage.rings.integer import Integer
-from sage.matrix.constructor import matrix
-from sage.matrix.special import zero_matrix, identity_matrix
-from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
-from sage.rings.finite_rings.integer_mod import mod
-from sage.rings.infinity import Infinity
-from sage.functions.generalized import sgn
-from sage.functions.other import ceil, floor
+from sage.all import SageObject, ZZ, QQ, NumberField, PolynomialRing, Polynomial, Integer, matrix, zero_matrix, identity_matrix, IntegerModRing, mod, Infinity, sgn, ceil, floor, prod, lcm, vector
 from sage.geometry.newton_polygon import NewtonPolygon
-from sage.misc.misc_c import prod
-from sage.arith.misc import lcm
-from sage.modules.free_module_element import vector
-
-ZZ = IntegerRing()
-QQ = RationalField()
+  
 
 
 #------------------------------------------------------------------------------

--- a/mclf/padic_extensions/fake_padic_completions.py
+++ b/mclf/padic_extensions/fake_padic_completions.py
@@ -84,30 +84,9 @@ TO DO:
 #*****************************************************************************
 
 
-from sage.structure.sage_object import SageObject
-from sage.rings.integer_ring import IntegerRing
-from sage.rings.rational_field import RationalField
-from sage.rings.number_field.number_field import NumberField
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.polynomial.polynomial_element import Polynomial
-from sage.rings.integer import Integer
-from sage.matrix.constructor import matrix
-from sage.matrix.special import zero_matrix, identity_matrix
-from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
-from sage.rings.finite_rings.integer_mod import mod
-from sage.rings.infinity import Infinity
-from sage.functions.generalized import sgn
-from sage.functions.other import ceil, floor
+from sage.all import SageObject, ZZ, QQ, NumberField, PolynomialRing, Polynomial, Integer, matrix, zero_matrix, identity_matrix, IntegerModRing, mod, Infinity, sgn, ceil, floor, prod, lcm, vector, GF
 from sage.geometry.newton_polygon import NewtonPolygon
-from sage.misc.misc_c import prod
-from sage.arith.misc import lcm
-from sage.modules.free_module_element import vector
-from sage.rings.finite_rings.finite_field_constructor import GF
 from sage.rings.valuation.limit_valuation import LimitValuation
-
-ZZ = IntegerRing()
-QQ = RationalField()
-
 
 
 class FakepAdicCompletion(SageObject):
@@ -321,10 +300,10 @@ class FakepAdicCompletion(SageObject):
         into `L_0`.
 
         """
-        # print "entering extension with "
-        # print "K = ", self
-        # print "f = ", f
-        # print
+        # print("entering extension with ")
+        # print("K = ", self)
+        # print("f = ", f)
+        # print()
 
         K0 = self.number_field()
         assert K0.has_coerce_map_from(f.parent().base_ring())
@@ -1075,9 +1054,9 @@ class FakepAdicCompletion(SageObject):
                 for k in range(n):
                     for l in range(n):
                         if vK(B_ij[k,l]) < 0:
-                            print "B[i,j] = ", B[i,j]
-                            print "vK(..) = ", vK(B[i,j])
-                            print "B_ij[k,l] = ", B_ij[k,l]
+                            print("B[i,j] = ", B[i,j])
+                            print("vK(..) = ", vK(B[i,j]))
+                            print("B_ij[k,l] = ", B_ij[k,l])
                             raise ValueError
                         BB[i*n+k, j*n+l] = R(B_ij[k,l])
         return BB.charpoly()
@@ -1127,7 +1106,7 @@ class FakepAdicCompletion(SageObject):
                 if v.mu() < Infinity:
                     V = v.mac_lane_step(f, assume_squarefree=True, check=False)
                     if len(V) > 1:
-                        print "len(V) > 1"
+                        print("len(V) > 1")
                         return None
                     v1 = V[0]
             # now v.phi().degree() = d, and either v1.phi().degree() > d
@@ -1140,13 +1119,13 @@ class FakepAdicCompletion(SageObject):
                         FakepAdicEmbedding(L, K)
                         # this can be very slow, but so far it is the only
                         # conclusive test I know
-                        # print "found subfield of degree %s and ramification degree %s"%(L.degree(), L.ramification_degree())
+                        # print("found subfield of degree %s and ramification degree %s"%(L.degree(), L.ramification_degree()))
                         return L
                     except AssertionError:
                         pass
-                        # print "no embedding into L!"
+                        # print("no embedding into L!")
             if v.mu() == Infinity:
-                print "v.mu() = Infinity"
+                print("v.mu() = Infinity")
                 return None
             else:
                 v = v1  # we go to a larger degree

--- a/mclf/padic_extensions/fake_padic_embeddings.py
+++ b/mclf/padic_extensions/fake_padic_embeddings.py
@@ -50,19 +50,9 @@ TO DO:
 #*****************************************************************************
 
 
-from sage.structure.sage_object import SageObject
-from sage.rings.integer_ring import IntegerRing
-from sage.rings.rational_field import RationalField
-from sage.rings.number_field.number_field import NumberField
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.polynomial.polynomial_element import Polynomial
-from sage.rings.infinity import Infinity
+from sage.all import SageObject, ZZ, QQ, NumberField, PolynomialRing, Polynomial, Infinity
 from mclf.padic_extensions.fake_padic_completions import FakepAdicCompletion
-
-
-ZZ = IntegerRing()
-QQ = RationalField()
-
+from sage.rings.valuation.limit_valuation import MacLaneLimitValuation, LimitValuation
 
 
 class FakepAdicEmbedding(SageObject):

--- a/mclf/padic_extensions/fake_padic_extensions.py
+++ b/mclf/padic_extensions/fake_padic_extensions.py
@@ -47,26 +47,10 @@ TO DO:
 #*****************************************************************************
 
 
-from sage.structure.sage_object import SageObject
-from sage.rings.number_field.number_field import NumberField
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.polynomial.polynomial_element import Polynomial
-from sage.rings.integer_ring import IntegerRing
-from sage.rings.rational_field import RationalField
-from sage.rings.finite_rings.integer_mod import mod
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
-from sage.functions.generalized import sgn
-from sage.functions.other import ceil
-from sage.misc.prandom import randint
+from sage.all import SageObject, NumberField, PolynomialRing, Polynomial, ZZ, QQ, mod, cached_method, Infinity, sgn, ceil, randint, prod, lcm
 from sage.geometry.newton_polygon import NewtonPolygon
-from sage.misc.misc_c import prod
-from sage.arith.misc import lcm
 from mclf.padic_extensions.fake_padic_completions import FakepAdicCompletion
 from mclf.padic_extensions.fake_padic_embeddings import FakepAdicEmbedding
-
-ZZ = IntegerRing()
-QQ = RationalField()
 
 
 class FakepAdicExtension(SageObject):

--- a/mclf/padic_extensions/slope_factors.py
+++ b/mclf/padic_extensions/slope_factors.py
@@ -39,9 +39,8 @@ polygon with slope `s` is moved to a segment of slope `0` with ordinate `0`.
 
 """
 
+from sage.all import ZZ
 from sage.geometry.newton_polygon import NewtonPolygon
-from sage.rings.integer_ring import IntegerRing
-ZZ = IntegerRing()
 
 
 def slope_factors(f, vK, precision, reduce_function, slope_bound=0):

--- a/mclf/padic_extensions/weak_padic_galois_extensions.py
+++ b/mclf/padic_extensions/weak_padic_galois_extensions.py
@@ -96,26 +96,10 @@ TO DO:
 #*****************************************************************************
 
 
-from sage.structure.sage_object import SageObject
-from sage.rings.number_field.number_field import NumberField
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.polynomial.polynomial_element import Polynomial
-from sage.rings.integer_ring import IntegerRing
-from sage.rings.rational_field import RationalField
-from sage.rings.finite_rings.integer_mod import mod
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
-from sage.functions.generalized import sgn
-from sage.functions.other import ceil
-from sage.misc.prandom import randint
+from sage.all import SageObject, NumberField, PolynomialRing, Polynomial, ZZ, QQ, mod, cached_method, Infinity, sgn, ceil, randint, prod, lcm
 from sage.geometry.newton_polygon import NewtonPolygon
-from sage.misc.misc_c import prod
-from sage.arith.misc import lcm
 from mclf.padic_extensions.fake_padic_completions import FakepAdicCompletion
 from mclf.padic_extensions.fake_padic_extensions import FakepAdicExtension
-
-ZZ = IntegerRing()
-QQ = RationalField()
 
 
 class WeakPadicGaloisExtension(FakepAdicExtension):

--- a/mclf/semistable_reduction/reduction_trees.py
+++ b/mclf/semistable_reduction/reduction_trees.py
@@ -132,8 +132,7 @@ TODO:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from sage.rings.all import ZZ, QQ, NumberField, FunctionField
+from sage.all import ZZ, QQ, NumberField, FunctionField, SageObject
 from mclf.berkovich.berkovich_line import *
 from mclf.berkovich.berkovich_trees import BerkovichTree
 from mclf.berkovich.type_V_points import TypeVPointOnBerkovichLine
@@ -522,8 +521,8 @@ class InertialComponent(SageObject):
                 else:
                     F = [L.absolute_polynomial().change_ring(K)]
             e = self.type_II_point().pseudovaluation_on_polynomial_ring().E()
-            print "F = ", F
-            print "e = ", e
+            print("F = ", F)
+            print("e = ", e)
             self._splitting_field = WeakPadicGaloisExtension(Kh, F, minimal_ramification=e)
         return self._splitting_field
 

--- a/mclf/semistable_reduction/superell.py
+++ b/mclf/semistable_reduction/superell.py
@@ -68,13 +68,7 @@ TO DO:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.function_field.constructor import FunctionField
-from sage.rings.valuation.gauss_valuation import GaussValuation
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
-from sage.functions.other import floor
+from sage.all import SageObject, PolynomialRing, FunctionField, GaussValuation, cached_method, Infinity, floor
 from mclf.berkovich.berkovich_line import *
 from mclf.berkovich.affinoid_domain import *
 from mclf.curves.smooth_projective_curves import SmoothProjectiveCurve
@@ -140,7 +134,7 @@ class Superell(SageObject):
         phi, psi, f1 = v0.monic_integral_model(f)
         # now f1 = phi(f).monic()
         if f1 != f.monic():
-            print "We make the coordinate change (x --> %s) in order to work with an integral polynomial f"%phi(R.gen())
+            print(("We make the coordinate change (x --> %s) in order to work with an integral polynomial f"%phi(R.gen())))
         self._f = f1
         a = phi(f).leading_coefficient()
         pi = vK.uniformizer()
@@ -209,36 +203,36 @@ class Superell(SageObject):
         computation and the result.
 
         """
-        print "We try to compute the semistable reduction of the"
-        print self
-        print "which has genus ", self.curve().genus()
-        print
+        print("We try to compute the semistable reduction of the")
+        print(self)
+        print(("which has genus ", self.curve().genus()))
+        print()
 
         reduction_tree = self.reduction_tree()
         inertial_components = reduction_tree.inertial_components()
         assert inertial_components != [], "no inertial components found! Something is wrong.."
         if len(inertial_components) > 1:
-            print "There are %s inertial components to consider: "%len(inertial_components)
+            print(("There are %s inertial components to consider: "%len(inertial_components)))
         else:
-            print "There is exactly one inertial component to consider:"
-        print
+            print("There is exactly one inertial component to consider:")
+        print()
         for Z in inertial_components:
-            print "Inertial component corresponding to "
-            print Z.interior()
-            print "It splits over ", Z.splitting_field().extension_field()
-            print "into %s lower components."%len(Z.lower_components())
-            print "The upper components are: "
+            print("Inertial component corresponding to ")
+            print(Z.interior())
+            print("It splits over ", Z.splitting_field().extension_field())
+            print("into %s lower components."%len(Z.lower_components()))
+            print("The upper components are: ")
             for W in Z.upper_components():
-                print W
+                print(W)
                 if W.field_of_constants_degree() > 1:
-                    print "   (note that this component is defined over an extension of degree %s over the residue field)"%W.field_of_constants_degree()
-            print "Contribution of this component to the reduction genus is ", Z.reduction_genus()
-            print
-        print
+                    print("   (note that this component is defined over an extension of degree %s over the residue field)"%W.field_of_constants_degree())
+            print("Contribution of this component to the reduction genus is ", Z.reduction_genus())
+            print()
+        print()
         if reduction_tree.is_semistable():
-            print "We have computed the semistable reduction of the curve."
+            print("We have computed the semistable reduction of the curve.")
         else:
-            print "We failed to compute the semistable reduction of the curve."
+            print("We failed to compute the semistable reduction of the curve.")
             raise ValueError()
 
 

--- a/mclf/semistable_reduction/superp.py
+++ b/mclf/semistable_reduction/superp.py
@@ -49,12 +49,7 @@ TO DO:
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from sage.structure.sage_object import SageObject
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.function_field.constructor import FunctionField
-from sage.misc.cachefunc import cached_method
-from sage.rings.infinity import Infinity
-from sage.functions.other import floor
+from sage.all import SageObject, PolynomialRing, FunctionField, cached_method, Infinity, floor
 from mclf.berkovich.berkovich_line import *
 from mclf.berkovich.affinoid_domain import *
 from mclf.curves.smooth_projective_curves import SmoothProjectiveCurve
@@ -155,7 +150,7 @@ class Superp(SageObject):
         phi, psi, f1 = v0.monic_integral_model(f)
         # now f1 = phi(f).monic()
         if f1 != f.monic():
-            print "We make the coordinate change (x --> %s) in order to work with an integral polynomial f"%phi(R.gen())
+            print("We make the coordinate change (x --> %s) in order to work with an integral polynomial f"%phi(R.gen()))
         self._f = f1
         a = phi(f).leading_coefficient()
         pi = vK.uniformizer()
@@ -338,45 +333,45 @@ class Superp(SageObject):
         computation and the result.
 
         """
-        print "We try to compute the semistable reduction of the"
-        print self
-        print "which has genus ", self.curve().genus()
-        print
-        print "First we compute the etale locus: "
-        print self.etale_locus()
+        print("We try to compute the semistable reduction of the")
+        print(self)
+        print("which has genus ", self.curve().genus())
+        print()
+        print("First we compute the etale locus: ")
+        print(self.etale_locus())
 
         reduction_tree = self.reduction_tree()
         inertial_components = reduction_tree.inertial_components()
         assert inertial_components != [], "no inertial components found! Something is wrong.."
         if len(inertial_components) > 1:
-            print "There are %s inertial components to consider: "%len(inertial_components)
+            print("There are %s inertial components to consider: "%len(inertial_components))
         else:
-            print "There is exactly one inertial component to consider:"
-        print
+            print("There is exactly one inertial component to consider:")
+        print()
         for Z in inertial_components:
-            print "inertial component corresponding to "
-            print Z.interior()
-            print "It splits over ", Z.splitting_field().extension_field()
-            print "into %s lower components."%len(Z.lower_components())
-            print "The upper components are: "
+            print("inertial component corresponding to ")
+            print(Z.interior())
+            print("It splits over ", Z.splitting_field().extension_field())
+            print("into %s lower components."%len(Z.lower_components()))
+            print("The upper components are: ")
             for W in Z.upper_components():
-                print W
+                print(W)
                 if W.field_of_constants_degree() > 1:
-                    print "   (note that this component is defined over an extension of degree %s over the residue field)"%W.field_of_constants_degree()
-            print "Contribution of this component to the reduction genus is ", Z.reduction_genus()
+                    print("   (note that this component is defined over an extension of degree %s over the residue field)"%W.field_of_constants_degree())
+            print("Contribution of this component to the reduction genus is ", Z.reduction_genus())
             print
         print
         if reduction_tree.is_semistable():
-            print "The curve has abelian reduction, since the total reduction genus"
-            print "is equal to the genus of the generic fiber."
+            print("The curve has abelian reduction, since the total reduction genus")
+            print("is equal to the genus of the generic fiber.")
         else:
-            print "We failed to compute the semistable reduction of the curve."
+            print("We failed to compute the semistable reduction of the curve.")
             if reduction_tree.is_reduced():
-                print "This is probably due to the fact that the curve does not have"
-                print "abelian reduction; the computation of the loops has not yet been realized."
+                print("This is probably due to the fact that the curve does not have")
+                print("abelian reduction; the computation of the loops has not yet been realized.")
             else:
-                print "Something went wrong! At least one of upper components has"
-                print "multiplicity > 1."
+                print("Something went wrong! At least one of upper components has")
+                print("multiplicity > 1.")
 
 
     def conductor_exponent(self):


### PR DESCRIPTION
* use relative imports
* use print()
* use raise Error()

I also simplified the imports, pulling everything from sage.all instead of
specifying the exact location. Using the import from the exact location is only
possibly interesting if we ever move this into the main Sage tree.

With these changes, the documentation essentially builds with a standard sphinx
and does not need sage's sphinx anymore.